### PR TITLE
feat: add autocomplete search for provider and model selection

### DIFF
--- a/src/helpers/ai.js
+++ b/src/helpers/ai.js
@@ -424,12 +424,111 @@ async function fetchOpenRouterModels(apiKey) {
   }
 }
 
+/**
+ * Fetch available models from OpenAI API
+ */
+async function fetchOpenAIModels(apiKey) {
+  try {
+    const response = await axios.get("https://api.openai.com/v1/models", {
+      headers: { Authorization: `Bearer ${apiKey}` },
+      timeout: 10000,
+    });
+    const models = response.data?.data || [];
+    return models
+      .map((m) => ({ id: m.id, name: m.id }))
+      .sort((a, b) => a.name.localeCompare(b.name));
+  } catch (error) {
+    return [];
+  }
+}
+
+/**
+ * Fetch available models from Anthropic (hardcoded list, no public API)
+ */
+async function fetchAnthropicModels() {
+  return [
+    { id: "claude-opus-4-20250514", name: "Claude Opus 4" },
+    { id: "claude-sonnet-4-20250514", name: "Claude Sonnet 4" },
+    { id: "claude-3-7-sonnet-20250219", name: "Claude 3.7 Sonnet" },
+    { id: "claude-3-5-sonnet-20241022", name: "Claude 3.5 Sonnet (New)" },
+    { id: "claude-3-5-sonnet-20240620", name: "Claude 3.5 Sonnet" },
+    { id: "claude-3-5-haiku-20241022", name: "Claude 3.5 Haiku" },
+    { id: "claude-3-opus-20240229", name: "Claude 3 Opus" },
+    { id: "claude-3-sonnet-20240229", name: "Claude 3 Sonnet" },
+    { id: "claude-3-haiku-20240307", name: "Claude 3 Haiku" },
+  ];
+}
+
+/**
+ * Fetch available models from Google Gemini API
+ */
+async function fetchGeminiModels(apiKey) {
+  try {
+    const response = await axios.get(
+      "https://generativelanguage.googleapis.com/v1beta/models",
+      {
+        headers: { "x-goog-api-key": apiKey },
+        timeout: 10000,
+      },
+    );
+    const models = response.data?.models || [];
+    return models
+      .filter((m) => m.supportedGenerationMethods?.includes("generateContent"))
+      .map((m) => {
+        const id = m.name.replace("models/", "");
+        return { id, name: m.displayName || id };
+      })
+      .sort((a, b) => a.name.localeCompare(b.name));
+  } catch (error) {
+    return [];
+  }
+}
+
+/**
+ * Fetch available models from Ollama
+ */
+async function fetchOllamaModels(url) {
+  try {
+    const response = await axios.get(`${url || "http://localhost:11434"}/api/tags`, {
+      timeout: 10000,
+    });
+    const models = response.data?.models || [];
+    return models
+      .map((m) => ({ id: m.name, name: m.name }))
+      .sort((a, b) => a.name.localeCompare(b.name));
+  } catch (error) {
+    return [];
+  }
+}
+
+/**
+ * Fetch available models from LM Studio
+ */
+async function fetchLMStudioModels(url) {
+  try {
+    const response = await axios.get(`${url || "http://localhost:1234"}/v1/models`, {
+      timeout: 10000,
+    });
+    const models = response.data?.data || [];
+    return models
+      .map((m) => ({ id: m.id, name: m.id }))
+      .sort((a, b) => a.name.localeCompare(b.name));
+  } catch (error) {
+    return [];
+  }
+}
+
 module.exports = {
   generateCommitMessage,
   generateCommitSuggestions,
   checkAIConnection,
   testProviderConnection,
   fetchOpenRouterModels,
+  fetchOpenAIModels,
+  fetchAnthropicModels,
+  fetchGeminiModels,
+  fetchOllamaModels,
+  fetchLMStudioModels,
   // Alias for backward compatibility
   checkLMStudioConnection: checkAIConnection,
 };

--- a/src/ui/modules/onboarding.js
+++ b/src/ui/modules/onboarding.js
@@ -1,10 +1,12 @@
 const inquirer = require("inquirer");
+const autocomplete = require("inquirer-autocomplete-prompt");
 const chalk = require("chalk");
 const boxen = require("boxen");
 const ora = require("ora");
 const { saveConfig, DEFAULT_CONFIG } = require("../../helpers/config");
-const { fetchOpenRouterModels } = require("../../helpers/ai");
 const { s, header, clear, sleep } = require("../common");
+
+inquirer.registerPrompt("autocomplete", autocomplete);
 
 /**
  * Onboarding workflow for new users
@@ -53,85 +55,65 @@ async function doOnboarding() {
   ]);
 
   // 2. Choose provider
+  const providerChoices = [
+    { name: "LM Studio (Local, no API key needed)", value: "lmstudio" },
+    { name: "OpenAI (GPT-4o, etc.)", value: "openai" },
+    { name: "Anthropic (Claude)", value: "anthropic" },
+    { name: "Google Gemini", value: "gemini" },
+    { name: "Ollama (Local)", value: "ollama" },
+    { name: "OpenRouter", value: "openrouter" }
+  ];
+
   const { provider } = await inquirer.prompt([
     {
-      type: "list",
+      type: "autocomplete",
       name: "provider",
-      message: "Which AI provider would you like to use?",
-      choices: [
-        { name: "LM Studio (Local, no API key needed)", value: "lmstudio" },
-        { name: "OpenAI (GPT-4o, etc.)", value: "openai" },
-        { name: "Anthropic (Claude)", value: "anthropic" },
-        { name: "Google Gemini", value: "gemini" },
-        { name: "Ollama (Local)", value: "ollama" },
-        { name: "OpenRouter", value: "openrouter" }
-      ]
+      message: "Which AI provider would you like to use? (type to search)",
+      source: (_answers, input) => {
+        if (!input) return providerChoices;
+        const term = input.toLowerCase();
+        return providerChoices.filter(
+          (c) =>
+            c.name.toLowerCase().includes(term) ||
+            c.value.toLowerCase().includes(term),
+        );
+      },
     }
   ]);
 
   let configData = { aiProvider: provider, theme };
+  let answers = {};
 
-  // Setup chosen provider
   if (provider === "openai") {
-    const answers = await inquirer.prompt([
-      { type: "input", name: "openaiApiKey", message: "Enter your OpenAI API Key:", validate: v => v.length > 0 },
-      { type: "input", name: "openaiModel", message: "Model name:", default: "gpt-4o" }
+    answers = await inquirer.prompt([
+      { type: "input", name: "openaiApiKey", message: "Enter your OpenAI API Key:", validate: v => v.length > 0 }
     ]);
-    configData = { ...configData, ...answers };
   } else if (provider === "anthropic") {
-    const answers = await inquirer.prompt([
-      { type: "input", name: "anthropicApiKey", message: "Enter your Anthropic API Key:", validate: v => v.length > 0 },
-      { type: "input", name: "anthropicModel", message: "Model name:", default: "claude-3-5-sonnet-20240620" }
+    answers = await inquirer.prompt([
+      { type: "input", name: "anthropicApiKey", message: "Enter your Anthropic API Key:", validate: v => v.length > 0 }
     ]);
-    configData = { ...configData, ...answers };
   } else if (provider === "gemini") {
-    const answers = await inquirer.prompt([
-      { type: "input", name: "geminiApiKey", message: "Enter your Google Gemini API Key:", validate: v => v.length > 0 },
-      { type: "input", name: "geminiModel", message: "Model name:", default: "gemini-2.0-flash" }
+    answers = await inquirer.prompt([
+      { type: "input", name: "geminiApiKey", message: "Enter your Google Gemini API Key:", validate: v => v.length > 0 }
     ]);
-    configData = { ...configData, ...answers };
   } else if (provider === "ollama") {
-    const answers = await inquirer.prompt([
-      { type: "input", name: "ollamaUrl", message: "Ollama URL:", default: "http://localhost:11434" },
-      { type: "input", name: "ollamaModel", message: "Model name:", default: "llama3" }
+    answers = await inquirer.prompt([
+      { type: "input", name: "ollamaUrl", message: "Ollama URL:", default: "http://localhost:11434" }
     ]);
-    configData = { ...configData, ...answers };
   } else if (provider === "openrouter") {
-    const { openrouterApiKey } = await inquirer.prompt([
+    answers = await inquirer.prompt([
       { type: "input", name: "openrouterApiKey", message: "Enter your OpenRouter API Key:", validate: v => v.length > 0 }
     ]);
-    
-    // We can use the existing function from settings to fetch models
-    const spinner = ora({ text: s.muted("  Fetching models from OpenRouter..."), spinner: "dots" }).start();
-    const models = await fetchOpenRouterModels(openrouterApiKey);
-    spinner.stop();
-
-    let model;
-    if (models.length > 0) {
-      const { selectedModel } = await inquirer.prompt([
-        {
-          type: "list",
-          name: "selectedModel",
-          message: "Select OpenRouter Model:",
-          choices: models.slice(0, 20).map(m => ({ name: m.name, value: m.id })),
-          default: "openai/gpt-4o"
-        }
-      ]);
-      model = selectedModel;
-    } else {
-      const { manualModel } = await inquirer.prompt([
-        { type: "input", name: "manualModel", message: "Model ID (manual):", default: "openai/gpt-4o" }
-      ]);
-      model = manualModel;
-    }
-    configData = { ...configData, openrouterApiKey, openrouterModel: model };
   } else if (provider === "lmstudio") {
-    const answers = await inquirer.prompt([
-      { type: "input", name: "lmStudioUrl", message: "LM Studio URL:", default: "http://localhost:1234" },
-      { type: "input", name: "model", message: "Model name/path:", default: "model-name" }
+    answers = await inquirer.prompt([
+      { type: "input", name: "lmStudioUrl", message: "LM Studio URL:", default: "http://localhost:1234" }
     ]);
-    configData = { ...configData, ...answers };
   }
+
+  configData = { ...configData, ...answers };
+
+  const modelAnswers = await require("./settings").promptModelSearch(provider, answers, DEFAULT_CONFIG);
+  configData = { ...configData, ...modelAnswers };
 
   // Save the config
   saveConfig(configData);

--- a/src/ui/modules/settings.js
+++ b/src/ui/modules/settings.js
@@ -6,9 +6,13 @@ const {
   checkAIConnection,
   testProviderConnection,
   fetchOpenRouterModels,
+  fetchOpenAIModels,
+  fetchAnthropicModels,
+  fetchGeminiModels,
+  fetchOllamaModels,
+  fetchLMStudioModels,
 } = require("../../helpers/ai");
 const { s, header, clear, sleep, truncate } = require("../common");
-const { doOnboarding } = require("./onboarding");
 
 inquirer.registerPrompt("autocomplete", autocomplete);
 
@@ -63,7 +67,7 @@ function getRequiredKeyField(provider) {
 }
 
 /**
- * Get configuration questions for a provider
+ * Get configuration questions for a provider (excluding model selection)
  */
 function getProviderQuestions(provider, config) {
   switch (provider) {
@@ -75,12 +79,6 @@ function getProviderQuestions(provider, config) {
           message: "OpenAI API Key:",
           default: config.openaiApiKey,
         },
-        {
-          type: "input",
-          name: "openaiModel",
-          message: "Model (e.g. gpt-4o, gpt-3.5-turbo):",
-          default: config.openaiModel,
-        },
       ];
     case "anthropic":
       return [
@@ -90,12 +88,6 @@ function getProviderQuestions(provider, config) {
           message: "Anthropic API Key:",
           default: config.anthropicApiKey,
         },
-        {
-          type: "input",
-          name: "anthropicModel",
-          message: "Model (e.g. claude-3-5-sonnet-20240620):",
-          default: config.anthropicModel,
-        },
       ];
     case "ollama":
       return [
@@ -104,12 +96,6 @@ function getProviderQuestions(provider, config) {
           name: "ollamaUrl",
           message: "Ollama URL:",
           default: config.ollamaUrl,
-        },
-        {
-          type: "input",
-          name: "ollamaModel",
-          message: "Model (e.g. llama3):",
-          default: config.ollamaModel,
         },
       ];
     case "openrouter":
@@ -129,12 +115,6 @@ function getProviderQuestions(provider, config) {
           message: "Google Gemini API Key:",
           default: config.geminiApiKey,
         },
-        {
-          type: "input",
-          name: "geminiModel",
-          message: "Model (e.g. gemini-2.0-flash, gemini-2.5-pro):",
-          default: config.geminiModel,
-        },
       ];
     default:
       return [
@@ -144,61 +124,104 @@ function getProviderQuestions(provider, config) {
           message: "LM Studio URL:",
           default: config.lmStudioUrl,
         },
-        {
-          type: "input",
-          name: "model",
-          message: "Model:",
-          default: config.model,
-        },
       ];
   }
 }
 
 /**
- * Prompt for OpenRouter model selection using autocomplete with models fetched from API
+ * Prompt for model selection using autocomplete with models fetched from the provider's API
  */
-async function promptOpenRouterModel(apiKey, currentModel) {
-  const spinner = ora({
-    text: s.muted("  Fetching models from OpenRouter..."),
-    spinner: "dots",
-  }).start();
+async function promptModelSearch(provider, answers, config) {
+  let models = [];
+  let currentModel = "";
+  let configKey = "";
+  let fetchLabel = "";
 
-  let models = await fetchOpenRouterModels(apiKey);
+  switch (provider) {
+    case "openai":
+      configKey = "openaiModel";
+      currentModel = config.openaiModel || "gpt-4o";
+      fetchLabel = "Fetching models from OpenAI...";
+      break;
+    case "anthropic":
+      configKey = "anthropicModel";
+      currentModel = config.anthropicModel || "claude-3-5-sonnet-20240620";
+      fetchLabel = "Loading Anthropic models...";
+      break;
+    case "gemini":
+      configKey = "geminiModel";
+      currentModel = config.geminiModel || "gemini-2.0-flash";
+      fetchLabel = "Fetching models from Gemini...";
+      break;
+    case "ollama":
+      configKey = "ollamaModel";
+      currentModel = config.ollamaModel || "llama3";
+      fetchLabel = "Fetching models from Ollama...";
+      break;
+    case "openrouter":
+      configKey = "openrouterModel";
+      currentModel = config.openrouterModel || "openai/gpt-4o";
+      fetchLabel = "Fetching models from OpenRouter...";
+      break;
+    case "lmstudio":
+    default:
+      configKey = "model";
+      currentModel = config.model || "";
+      fetchLabel = "Fetching models from LM Studio...";
+      break;
+  }
+
+  const spinner = ora({ text: s.muted("  " + fetchLabel), spinner: "dots" }).start();
+
+  switch (provider) {
+    case "openai":
+      models = await fetchOpenAIModels(answers.openaiApiKey || config.openaiApiKey);
+      break;
+    case "anthropic":
+      models = await fetchAnthropicModels();
+      break;
+    case "gemini":
+      models = await fetchGeminiModels(answers.geminiApiKey || config.geminiApiKey);
+      break;
+    case "ollama":
+      models = await fetchOllamaModels(answers.ollamaUrl || config.ollamaUrl);
+      break;
+    case "openrouter":
+      models = await fetchOpenRouterModels(answers.openrouterApiKey || config.openrouterApiKey);
+      break;
+    case "lmstudio":
+    default:
+      models = await fetchLMStudioModels(answers.lmStudioUrl || config.lmStudioUrl);
+      break;
+  }
+
   spinner.stop();
 
   if (models.length === 0) {
     console.log(
-      s.muted("  Could not fetch models. You can type a model ID manually."),
+      s.muted("  Could not fetch models. You can type a model name manually."),
     );
-    const { openrouterModel } = await inquirer.prompt([
+    const result = await inquirer.prompt([
       {
         type: "input",
-        name: "openrouterModel",
-        message: "Model ID:",
-        default: currentModel || "openai/gpt-4o",
+        name: configKey,
+        message: "Model:",
+        default: currentModel,
       },
     ]);
-    return openrouterModel;
+    return result;
   }
 
-  // Sort: free models first, then by name
-  models.sort((a, b) => {
-    const aFree = parseFloat(a.pricing?.prompt || "1") === 0;
-    const bFree = parseFloat(b.pricing?.prompt || "1") === 0;
-    if (aFree !== bFree) return aFree ? -1 : 1;
-    return a.name.localeCompare(b.name);
-  });
+  const modelChoices = models.map((m) => ({
+    name: m.name !== m.id ? `${m.name}  (${m.id})` : m.name,
+    value: m.id,
+    short: m.id,
+  }));
 
-  const modelChoices = models.map((m) => {
-    const isFree = parseFloat(m.pricing?.prompt || "1") === 0;
-    const label = isFree ? `${m.name}  [free]` : m.name;
-    return { name: label, value: m.id, short: m.id };
-  });
-
-  const { openrouterModel } = await inquirer.prompt([
+  const result = await inquirer.prompt([
     {
       type: "autocomplete",
-      name: "openrouterModel",
+      name: configKey,
       message: "Select Model (type to search):",
       source: (_answers, input) => {
         if (!input) return modelChoices;
@@ -209,28 +232,24 @@ async function promptOpenRouterModel(apiKey, currentModel) {
             c.value.toLowerCase().includes(term),
         );
       },
-      default: currentModel || "openai/gpt-4o",
+      default: currentModel,
       pageSize: 15,
     },
   ]);
 
-  return openrouterModel;
+  return result;
 }
 
 /**
- * Ask provider configuration and return answers (handles OpenRouter model selection specially)
+ * Ask provider configuration and return answers (handles model selection with autocomplete for all providers)
  */
 async function askProviderConfig(provider, config) {
   const questions = getProviderQuestions(provider, config);
-  const answers = await inquirer.prompt(questions);
+  const answers = questions.length > 0 ? await inquirer.prompt(questions) : {};
 
-  if (provider === "openrouter") {
-    const apiKey = answers.openrouterApiKey || config.openrouterApiKey;
-    const model = await promptOpenRouterModel(apiKey, config.openrouterModel);
-    answers.openrouterModel = model;
-  }
+  const modelAnswers = await promptModelSearch(provider, answers, config);
 
-  return answers;
+  return { ...answers, ...modelAnswers };
 }
 
 async function doSettings() {
@@ -343,28 +362,37 @@ async function doSettings() {
         s.success("\n  ✓ Settings reset to default. Starting onboarding..."),
       );
       await sleep(1000);
-      await doOnboarding();
+      await require("./onboarding").doOnboarding();
       return;
     }
     return;
   }
 
   if (action === "provider") {
+    const providerChoices = [
+      { name: "LM Studio (Local)", value: "lmstudio" },
+      { name: "OpenAI", value: "openai" },
+      { name: "Anthropic (Claude)", value: "anthropic" },
+      { name: "Ollama (Local)", value: "ollama" },
+      { name: "OpenRouter", value: "openrouter" },
+      { name: "Google Gemini", value: "gemini" },
+    ];
+
     const { provider } = await inquirer.prompt([
       {
-        type: "list",
+        type: "autocomplete",
         name: "provider",
-        message: s.muted("Select AI Provider:"),
-        choices: [
-          { name: "LM Studio (Local)", value: "lmstudio" },
-          { name: "OpenAI", value: "openai" },
-          { name: "Anthropic (Claude)", value: "anthropic" },
-          { name: "Ollama (Local)", value: "ollama" },
-          { name: "OpenRouter", value: "openrouter" },
-          { name: "Google Gemini", value: "gemini" },
-        ],
+        message: s.muted("Select AI Provider (type to search):"),
+        source: (_answers, input) => {
+          if (!input) return providerChoices;
+          const term = input.toLowerCase();
+          return providerChoices.filter(
+            (c) =>
+              c.name.toLowerCase().includes(term) ||
+              c.value.toLowerCase().includes(term),
+          );
+        },
         default: config.aiProvider,
-        loop: true,
         pageSize: 15,
       },
     ]);
@@ -428,4 +456,4 @@ async function doSettings() {
   }
 }
 
-module.exports = { doSettings };
+module.exports = { doSettings, promptModelSearch };


### PR DESCRIPTION
## Changes

- Added model fetching functions for all providers (OpenAI, Anthropic, Gemini, Ollama, LM Studio) in \i.js\
- Replaced static \list\ prompts with \utocomplete\ prompts for both provider and model selection
- Users can now type to search/filter providers and models in settings and onboarding flows
- Fallback to manual input when API is unreachable